### PR TITLE
Update site content to reflect graduate status

### DIFF
--- a/src/about.njk
+++ b/src/about.njk
@@ -9,7 +9,7 @@ description: Learn about Levi Huff's background in Information Technology, profe
     <div class="about-text">
       <h1>About Me</h1>
       <p>
-        I'm an Information Technology student at the University of Cincinnati, pursuing a Bachelor of Science in Information Technology with a focus on software and application development. I'm expected to graduate in May 2026.
+        I'm an Information Technology professional based in Cincinnati. I recently graduated from the University of Cincinnati with a Bachelor of Science in Information Technology, with a focus on software and application development.
       </p>
       <p>
         My experience spans academic coursework, personal projects, and professional work involving internal tools, automation, and systems support. I've worked with both development and IT support contexts, which has shaped a practical approach to building and improving systems.
@@ -27,7 +27,7 @@ description: Learn about Levi Huff's background in Information Technology, profe
     <strong>University of Cincinnati</strong><br>
     Bachelor of Science in Information Technology<br>
     Focus: Software and Application Development<br>
-    Expected Graduation: May 2026
+    Graduated: May 2026
   </p>
 </section>
 
@@ -166,7 +166,7 @@ description: Learn about Levi Huff's background in Information Technology, profe
 <section class="page-section">
   <h2>Looking Ahead</h2>
   <p>
-    I am seeking internship or entry-level roles where I can continue learning, contribute to production systems, and support teams through reliable and thoughtful technical work. I'm particularly interested in opportunities that involve systems administration, software development, or process improvement.
+    I am looking for full-time roles where I can contribute to production systems and support teams through reliable and thoughtful technical work. I'm particularly interested in positions involving systems administration, software development, or process improvement.
   </p>
   <div class="cta-inline">
     <a href="/projects/">View projects</a>

--- a/src/contact.njk
+++ b/src/contact.njk
@@ -1,13 +1,13 @@
 ---
 layout: base.njk
 title: Contact | Levi Huff
-description: Get in touch with Levi Huff for internship opportunities, entry-level positions, or collaborative projects in software development and IT.
+description: Get in touch with Levi Huff for full-time opportunities or collaborative projects in software development and IT.
 ---
 
 <section>
   <h1>Get in Touch</h1>
   <p class="lead">
-    I'm open to internships, entry-level positions, and collaborative opportunities. Feel free to reach out if you'd like to discuss potential opportunities or have questions about my work.
+    I'm open to full-time positions and collaborative opportunities. Feel free to reach out if you'd like to discuss potential opportunities or have questions about my work.
   </p>
 
   <div class="contact-grid">
@@ -29,7 +29,7 @@ description: Get in touch with Levi Huff for internship opportunities, entry-lev
     <div class="contact-card">
       <h2>What I'm Looking For</h2>
       <p>
-        I am currently seeking internship or entry-level roles in information technology, software development, or systems administration.
+        I am currently seeking full-time roles in information technology, software development, or systems administration.
       </p>
 
       <h3>Areas of Interest</h3>
@@ -42,7 +42,7 @@ description: Get in touch with Levi Huff for internship opportunities, entry-lev
       </ul>
 
       <div class="availability-note">
-        <p><strong>Availability:</strong> Available for internships and full-time positions. Expected graduation: August 2025.</p>
+        <p><strong>Availability:</strong> Available for full-time positions. Graduated May 2026 from the University of Cincinnati.</p>
       </div>
     </div>
   </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -1,7 +1,7 @@
 ---
 layout: base.njk
-title: Levi Huff | IT Student & Developer
-description: Information Technology student at University of Cincinnati specializing in full-stack development, systems administration, and process automation. Seeking internships and entry-level opportunities.
+title: Levi Huff | IT Professional & Developer
+description: Information Technology graduate from the University of Cincinnati specializing in full-stack development, systems administration, and process automation. Open to full-time roles in software development and IT.
 ---
 
 <!-- Hero -->
@@ -12,11 +12,11 @@ description: Information Technology student at University of Cincinnati speciali
       <h1>Levi Huff</h1>
 
       <p class="lead">
-        Full-stack developer and IT student specializing in software development, systems administration, and process automation.
+        Full-stack developer and IT professional specializing in software development, systems administration, and process automation.
       </p>
 
       <p>
-        Currently pursuing a Bachelor of Science in Information Technology at the University of Cincinnati with a focus on software and application development. Expected graduation: May 2026.
+        Recently graduated with a Bachelor of Science in Information Technology from the University of Cincinnati, with a focus on software and application development.
       </p>
 
       <p>
@@ -83,7 +83,7 @@ description: Information Technology student at University of Cincinnati speciali
   <h2>Looking Ahead</h2>
 
   <p>
-    I am seeking internship or entry-level roles where I can continue learning, contribute to production systems, and support teams through reliable and thoughtful technical work. I'm particularly interested in opportunities involving full-stack development, systems administration, or process automation.
+    I am looking for full-time roles where I can contribute to production systems and support teams through reliable and thoughtful technical work. I'm particularly interested in positions involving full-stack development, systems administration, or process automation.
   </p>
 
   <div class="cta-inline">


### PR DESCRIPTION
Replace all student/internship-seeking language with graduate positioning. Fix incorrect August 2025 graduation date on contact page to May 2026. Update title, descriptions, and body copy across index, about, and contact pages.