### PR TITLE
fix: section-aware nav active state, complete 404 nav, close mobile m…

### DIFF
--- a/src/404.njk
+++ b/src/404.njk
@@ -15,7 +15,9 @@ eleventyExcludeFromCollections: true
     <nav class="error-nav" aria-label="Error page navigation">
       <ul>
         <li><a href="/">Home</a></li>
+        <li><a href="/about/">About</a></li>
         <li><a href="/projects/">Projects</a></li>
+        <li><a href="/resume/">Resume</a></li>
         <li><a href="/blog/">Blog</a></li>
         <li><a href="/contact/">Contact</a></li>
       </ul>

--- a/src/_includes/components/nav.njk
+++ b/src/_includes/components/nav.njk
@@ -8,7 +8,8 @@
     <nav id="nav-menu" aria-label="Main navigation">
       <ul>
         {% for item in navigation %}
-          <li><a href="{{ item.url }}" {% if page.url == item.url %}aria-current="page"{% endif %}>{{ item.label }}</a></li>
+          {% set isActive = (item.url == "/" and page.url == "/") or (item.url != "/" and page.url.startsWith(item.url)) %}
+          <li><a href="{{ item.url }}"{% if isActive %} aria-current="page"{% endif %}>{{ item.label }}</a></li>
         {% endfor %}
       </ul>
     </nav>

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -101,6 +101,14 @@
             navMenu.classList.remove('is-open');
           }
         });
+
+        // Close when a nav link is clicked (useful for anchor links or same-page navigation)
+        navMenu.querySelectorAll('a').forEach(function (link) {
+          link.addEventListener('click', function () {
+            navToggle.setAttribute('aria-expanded', 'false');
+            navMenu.classList.remove('is-open');
+          });
+        });
       }
 
       var btn = document.querySelector('.back-to-top');


### PR DESCRIPTION
…enu on link click

- nav.njk: replace exact URL equality with prefix match so the active link highlights correctly on nested routes (e.g. Blog on /blog/* posts)
- 404.njk: add missing About and Resume links to the in-body error nav so it is consistent with navigation.json order
- base.njk: close mobile drawer when a nav link is clicked