### PR TITLE
fix(infra): remove .htaccess passthrough (FTP 553)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,7 +27,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/files");
   eleventyConfig.addPassthroughCopy("robots.txt");
   eleventyConfig.addPassthroughCopy("_headers");
-  eleventyConfig.addPassthroughCopy("src/.htaccess");
   eleventyConfig.addPassthroughCopy("src/humans.txt");
 
   // Create blog posts collection

--- a/_headers
+++ b/_headers
@@ -1,7 +1,6 @@
 # DEFENSIVE ARTIFACT — NOT ACTIVE ON PORKBUN
-# Porkbun uses Apache; this Netlify/Cloudflare Pages convention is silently
-# ignored on the current host. Live headers are served via src/.htaccess.
-# Keep this file for any future migration to Netlify / Cloudflare Pages.
+# Porkbun static hosting ignores this file. No custom headers are served on
+# the current host. Keep for any future migration to Netlify / Cloudflare Pages.
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,7 +1,8 @@
-# levihuff.net — Apache configuration for Porkbun static hosting
-# LIVE source of truth for caching and security headers.
-# The repo-root _headers file is a defensive artifact for any future
-# migration to Netlify / Cloudflare Pages; it is NOT served by Porkbun.
+# DEFENSIVE ARTIFACT — NOT DEPLOYED.
+# Porkbun static hosting rejects .htaccess uploads (FTP 553) and does not
+# run Apache. Retained as documentation of intended cache/security headers
+# if the site ever migrates to an Apache host. To activate, re-add
+# eleventyConfig.addPassthroughCopy("src/.htaccess") in .eleventy.js.
 
 # ── Cache-Control ──────────────────────────────────────────────────────────
 <IfModule mod_headers.c>


### PR DESCRIPTION
## Summary

- Removes `eleventyConfig.addPassthroughCopy("src/.htaccess")` from `.eleventy.js` so the file is no longer copied into `_site/` or uploaded during deploy
- Porkbun static hosting rejects `.htaccess` uploads with FTP 553 and does not run Apache, so the file was never going to be honoured
- Updates `src/.htaccess` header comment to match the `_headers` "defensive artifact" pattern — kept for documentation and any future Apache-host migration
- Corrects stale claim in `_headers` that `.htaccess` was the live mechanism on Porkbun

## Trade-off

Cache-control and security headers from `ac98723` will not be active on the current host. Future options: Cloudflare in front, or migrate to a host that honours `_headers` (Netlify / Cloudflare Pages — the file is already in the repo).

## Test plan

- [ ] `npm run build` → `_site/.htaccess` absent
- [ ] Deploy action completes without FTP 553

🤖 Generated with [Claude Code](https://claude.com/claude-code)