### PR TITLE
fix(infra): use Header always set for cache headers

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/files");
   eleventyConfig.addPassthroughCopy("robots.txt");
   eleventyConfig.addPassthroughCopy("_headers");
+  eleventyConfig.addPassthroughCopy("src/.htaccess");
   eleventyConfig.addPassthroughCopy("src/humans.txt");
 
   // Create blog posts collection

--- a/_headers
+++ b/_headers
@@ -1,6 +1,7 @@
 # DEFENSIVE ARTIFACT — NOT ACTIVE ON PORKBUN
-# Porkbun static hosting ignores this file. No custom headers are served on
-# the current host. Keep for any future migration to Netlify / Cloudflare Pages.
+# Porkbun uses Apache; this Netlify/Cloudflare Pages convention is silently
+# ignored on the current host. Live headers are served via src/.htaccess.
+# Keep this file for any future migration to Netlify / Cloudflare Pages.
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,30 +1,29 @@
-# DEFENSIVE ARTIFACT — NOT DEPLOYED.
-# Porkbun static hosting rejects .htaccess uploads (FTP 553) and does not
-# run Apache. Retained as documentation of intended cache/security headers
-# if the site ever migrates to an Apache host. To activate, re-add
-# eleventyConfig.addPassthroughCopy("src/.htaccess") in .eleventy.js.
+# levihuff.net — Apache configuration for Porkbun static hosting
+# LIVE source of truth for caching and security headers.
+# The repo-root _headers file is a defensive artifact for any future
+# migration to Netlify / Cloudflare Pages; it is NOT served by Porkbun.
 
 # ── Cache-Control ──────────────────────────────────────────────────────────
 <IfModule mod_headers.c>
   # CSS/JS: no content-hash fingerprinting, so omit immutable. 1-day cache
   # means returning visitors get fast repeat loads; changes land within 24h.
   <FilesMatch "\.(css|js)$">
-    Header set Cache-Control "public, max-age=86400"
+    Header always set Cache-Control "public, max-age=86400"
   </FilesMatch>
 
   # Images, fonts, PDF: change rarely in practice; 1-week cache is safe.
   <FilesMatch "\.(jpg|jpeg|png|gif|svg|webp|ico|woff|woff2|ttf|otf|pdf)$">
-    Header set Cache-Control "public, max-age=604800"
+    Header always set Cache-Control "public, max-age=604800"
   </FilesMatch>
 
   # HTML — short cache; revalidate on each visit
   <FilesMatch "\.html$">
-    Header set Cache-Control "public, max-age=3600, must-revalidate"
+    Header always set Cache-Control "public, max-age=3600, must-revalidate"
   </FilesMatch>
 
   # XML feeds and sitemaps — short cache
   <FilesMatch "\.(xml|txt)$">
-    Header set Cache-Control "public, max-age=3600, must-revalidate"
+    Header always set Cache-Control "public, max-age=3600, must-revalidate"
   </FilesMatch>
 
   # ── Security Headers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Switches all `Cache-Control` directives in `src/.htaccess` from `Header set` to `Header always set` so our values take precedence over any host-level caching rules Porkbun applies
- Re-adds `eleventyConfig.addPassthroughCopy("src/.htaccess")` — the FTP 553 on initial deploy was a file-creation permission issue; now that the file exists on the server (uploaded via Cyberduck), the deploy action can overwrite it going forward
- Restores accurate comments in `_headers` (`.htaccess` is the live mechanism on Porkbun)

## Test plan

- [ ] Deploy succeeds without FTP 553
- [ ] `curl -I https://levihuff.net/css/styles.css` shows `Cache-Control: public, max-age=86400`

🤖 Generated with [Claude Code](https://claude.com/claude-code)