### PR TITLE
fix(watch): emit stylesheet when running npm run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev:11ty": "eleventy --serve",
     "dev:css": "tailwindcss -i ./src/_includes/css/tailwind.css -o ./_site/css/styles.css --watch",
     "build": "eleventy && tailwindcss -i ./src/_includes/css/tailwind.css -o ./_site/css/styles.css --minify",
-    "watch": "eleventy --watch",
+    "watch": "npm-run-all --parallel watch:11ty watch:css",
+    "watch:11ty": "eleventy --watch",
+    "watch:css": "tailwindcss -i ./src/_includes/css/tailwind.css -o ./_site/css/styles.css --watch",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

Fixes #24

- `npm run watch` only launched `eleventy --watch`, so `_site/css/styles.css` was never written during a watch session
- Since `src/css` is no longer passthrough-copied (Tailwind builds the stylesheet directly to `_site/css/`), the site was left unstyled
- Added `watch:11ty` and `watch:css` sub-scripts and updated `watch` to run them in parallel via `npm-run-all`, matching the documented watch workflow

## Test plan

- [ ] Run `npm run watch` and confirm `_site/css/styles.css` is created on startup
- [ ] Edit a template file and confirm Eleventy rebuilds HTML
- [ ] Edit a source CSS/template file and confirm Tailwind rebuilds the stylesheet
- [ ] Confirm no local dev server is started (watch vs start distinction preserved)

https://claude.ai/code/session_01NGoyV3ihwVrP8cuHjkd5qn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGoyV3ihwVrP8cuHjkd5qn)_