### PR TITLE
Add Vue CDN islands and Motion One scroll animations

### DIFF
--- a/src/_data/projects.json
+++ b/src/_data/projects.json
@@ -2,6 +2,7 @@
   {
     "title": "Multi-LLM Dev Workflow",
     "featured": true,
+    "category": "ai",
     "stack": "Claude Code, Codex, Gemini, Ollama",
     "summary": "Three-provider AI workflow routing tasks by model strength: Claude Code as orchestrator, Codex as async adversarial reviewer, Gemini for large-context analysis.",
     "link": null,
@@ -23,6 +24,7 @@
   {
     "title": "Proxmox Homelab & Docker Stack",
     "featured": true,
+    "category": "infrastructure",
     "stack": "Proxmox, Docker, Pi-hole",
     "summary": "Migrated self-hosted services from individual LXCs to a unified Docker stack; configured subnet static routing to isolate household services from upstream failures.",
     "link": null,
@@ -43,6 +45,7 @@
   {
     "title": "Windows Imaging and PXE Automation",
     "featured": true,
+    "category": "infrastructure",
     "stack": "FOG, MDT, WDS, UEFI",
     "summary": "Built a PXE boot and automated imaging pipeline at two co-op employers. Cut Windows 11 deployment from two hours to under 20 minutes per machine.",
     "link": null,
@@ -64,6 +67,7 @@
   {
     "title": "AeroAssist",
     "featured": true,
+    "category": "software",
     "stack": "C#, ASP.NET, MSSQL",
     "summary": "Full-stack ticketing system for ticket creation, tracking, and workflow handoffs. Built and deployed end to end.",
     "link": "https://lh1207.github.io/AeroAssist/",
@@ -83,6 +87,7 @@
   },
   {
     "title": "LocoQuest",
+    "category": "software",
     "link": "https://github.com/lh1207/LocoQuest",
     "linkLabel": "View on GitHub",
     "image": "/images/locoquest/hero-outdoor-map.jpg",
@@ -101,6 +106,7 @@
   {
     "title": "Culinary Mastery",
     "featured": true,
+    "category": "software",
     "stack": "React Native, Node.js, Azure AI",
     "summary": "Cooking-education platform with Azure-backed auth and AI-driven explanations. UC Senior Design Group 7, IT Expo 2025.",
     "link": "https://github.com/24-25-UC-Senior-Design-Group-7/Culinary-Mastery",
@@ -121,6 +127,7 @@
   },
   {
     "title": "UCRelief",
+    "category": "software",
     "link": "https://therelievers.weebly.com/",
     "linkLabel": "View Project",
     "image": "https://images.unsplash.com/photo-1758270705518-b61b40527e76?w=1200&h=800&fit=crop&auto=format&q=80",
@@ -139,6 +146,7 @@
   },
   {
     "title": "Computer Imaging and Provisioning Automation",
+    "category": "work",
     "link": null,
     "linkLabel": null,
     "image": "https://images.unsplash.com/photo-1643199121319-b3b5695e4acb?w=1200&h=800&fit=crop&auto=format&q=80",
@@ -156,6 +164,7 @@
   },
   {
     "title": "IT Support and Process Improvement",
+    "category": "work",
     "link": null,
     "linkLabel": null,
     "image": "https://images.unsplash.com/photo-1598970434795-0c54fe7c0648?w=1200&h=800&fit=crop&auto=format&q=80",
@@ -173,6 +182,7 @@
   },
   {
     "title": "Machine Lifecycle and Decommissioning",
+    "category": "work",
     "link": null,
     "linkLabel": null,
     "image": "https://images.unsplash.com/photo-1717444309231-8ef42dfe2936?w=1200&h=800&fit=crop&auto=format&q=80",
@@ -190,6 +200,7 @@
   },
   {
     "title": "End-User Equipment Moves",
+    "category": "work",
     "link": null,
     "linkLabel": null,
     "image": "https://images.unsplash.com/photo-1742198865450-cf9ce4335a33?w=1200&h=800&fit=crop&auto=format&q=80",

--- a/src/_includes/components/landing/project-card-mini.njk
+++ b/src/_includes/components/landing/project-card-mini.njk
@@ -1,4 +1,4 @@
-<article class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
+<article data-motion="stagger-item" class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
   {% if project.image %}
     <img
       src="{{ project.image }}"

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -69,6 +69,34 @@
     aria-label="Back to top"
     hidden>&#8679;</button>
 
+  <script type="module">
+    import { animate, inView, stagger } from 'https://cdn.jsdelivr.net/npm/motion@10/dist/motion.js';
+
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      // Hero stagger — only on the homepage
+      const hero = document.getElementById('hero');
+      if (hero) {
+        const items = hero.querySelectorAll('[data-motion="hero-item"]');
+        if (items.length) {
+          animate(items, { opacity: [0, 1], y: [20, 0] }, { delay: stagger(0.12), duration: 0.5, easing: [0.25, 0.1, 0.25, 1] });
+        }
+      }
+
+      // Section reveal — headings and content blocks
+      inView('[data-motion="section"]', ({ target }) => {
+        animate(target, { opacity: [0, 1], y: [20, 0] }, { duration: 0.45, easing: [0.25, 0.1, 0.25, 1] });
+      }, { margin: '-8% 0px' });
+
+      // Stagger grids
+      inView('[data-motion="stagger"]', ({ target }) => {
+        const items = target.querySelectorAll('[data-motion="stagger-item"]');
+        if (items.length) {
+          animate(items, { opacity: [0, 1], y: [12, 0] }, { delay: stagger(0.05), duration: 0.35, easing: [0.25, 0.1, 0.25, 1] });
+        }
+      }, { margin: '-8% 0px' });
+    }
+  </script>
+
   <script>
     (function () {
       // Year in footer

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -49,6 +49,7 @@
   <link rel="author" href="/humans.txt">
   <link rel="me" href="{{ site.social.github }}">
   <link rel="stylesheet" href="/css/styles.css">
+  <style>[v-cloak]{display:none;}</style>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&family=JetBrains+Mono:wght@400;500;600&family=Syne:wght@600;700;800&display=swap">

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -71,7 +71,7 @@
     hidden>&#8679;</button>
 
   <script type="module">
-    import { animate, inView, stagger } from 'https://cdn.jsdelivr.net/npm/motion@10/dist/motion.js';
+    import { animate, inView, stagger } from 'https://cdn.jsdelivr.net/npm/motion@10.18.0/+esm';
 
     if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       // Hero stagger — only on the homepage

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -24,7 +24,7 @@ description: Technical blog posts covering full-stack development, systems admin
   <section class="pb-16 md:pb-20">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <div id="blog-app">
+      <div id="blog-app" v-cloak>
         {# Vue mounts here; static fallback shown until hydration #}
         <div v-if="false"></div>
 

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -24,10 +24,39 @@ description: Technical blog posts covering full-stack development, systems admin
   <section class="pb-16 md:pb-20">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <div id="blog-app" v-cloak>
-        {# Vue mounts here; static fallback shown until hydration #}
-        <div v-if="false"></div>
+      {# Static fallback — always visible; Vue removes it on mount #}
+      <div id="blog-static" class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {% set postslist = collections.posts | reverse %}
+        {% for post in postslist %}
+        <article class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
+          {% if post.data.thumbnail %}
+          <div class="h-44 bg-surface-inset overflow-hidden">
+            <img src="{{ post.data.thumbnail }}" alt="" loading="lazy" class="w-full h-full {% if post.data.thumbnailLogo %}object-contain p-6{% else %}object-cover{% endif %}">
+          </div>
+          {% endif %}
+          <div class="p-6">
+            <h2 class="font-syne text-lg font-semibold text-fg-1 leading-snug">
+              <a href="{{ post.url }}" class="hover:text-amber transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">{{ post.data.title }}</a>
+            </h2>
+            {% if post.data.description %}
+            <p class="font-plex text-sm text-fg-2 leading-relaxed mt-2">{{ post.data.description }}</p>
+            {% endif %}
+            <div class="mt-4 flex flex-wrap items-center gap-2">
+              <span class="font-jb text-mono-sm text-fg-3">{{ post.date | dateReadable }}</span>
+              <span class="font-jb text-mono-sm text-fg-4">&middot;</span>
+              <span class="font-jb text-mono-sm text-fg-3">{{ post.templateContent | readingTime }}</span>
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2">
+              {% for tag in post.data.tags %}{% if tag !== "posts" %}
+              <span class="font-jb text-mono-xs tracking-[0.04em] uppercase bg-amber/[0.10] border border-amber/[0.32] text-amber rounded-d-sm px-2 py-0.5">{{ tag }}</span>
+              {% endif %}{% endfor %}
+            </div>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
 
+      <div id="blog-app" v-cloak>
         {# Tag filter chips #}
         <div class="flex flex-wrap gap-2 mb-8" v-if="allTags.length">
           <button
@@ -140,6 +169,9 @@ createApp({
         .map(p => ({ ...p, visibleTags: p.tags.filter(t => t !== 'posts') }))
         .filter(p => active === 'all' || p.tags.includes(active));
     }
+  },
+  mounted() {
+    document.getElementById('blog-static')?.remove();
   }
 }).mount('#blog-app');
 </script>

--- a/src/blog/index.njk
+++ b/src/blog/index.njk
@@ -24,63 +24,130 @@ description: Technical blog posts covering full-stack development, systems admin
   <section class="pb-16 md:pb-20">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      {% set postslist = collections.posts | reverse %}
-      {% if postslist.length %}
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {% for post in postslist %}
-        <article class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
+      <div id="blog-app">
+        {# Vue mounts here; static fallback shown until hydration #}
+        <div v-if="false"></div>
 
-          {% if post.data.thumbnail %}
-          <div class="h-44 bg-surface-inset overflow-hidden">
-            <img
-              src="{{ post.data.thumbnail }}"
-              alt=""
-              loading="lazy"
-              class="w-full h-full object-cover {% if post.data.thumbnailLogo %}object-contain p-6{% endif %}">
-          </div>
-          {% endif %}
+        {# Tag filter chips #}
+        <div class="flex flex-wrap gap-2 mb-8" v-if="allTags.length">
+          <button
+            v-for="tag in ['all', ...allTags]"
+            :key="tag"
+            @click="activeTag = tag"
+            :aria-pressed="activeTag === tag"
+            :class="[
+              'font-jb text-mono-xs tracking-[0.04em] uppercase px-3 py-1.5 rounded-d-sm border transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2',
+              activeTag === tag
+                ? 'bg-amber/[0.18] border-amber/[0.64] text-amber'
+                : 'bg-surface-2 border-hair-1 text-fg-3 hover:text-fg-1 hover:border-hair-2'
+            ]">
+            {% raw %}{{ tag === 'all' ? 'All' : tag }}{% endraw %}
+          </button>
+        </div>
 
-          <div class="p-6">
-            <h2 class="font-syne text-lg font-semibold text-fg-1 leading-snug">
-              <a
-                href="{{ post.url }}"
-                class="hover:text-amber transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
-                {{ post.data.title }}
-              </a>
-            </h2>
+        {# Posts grid #}
+        <transition-group
+          tag="div"
+          name="card"
+          class="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
+          v-if="filteredPosts.length">
+          <article
+            v-for="post in filteredPosts"
+            :key="post.url"
+            class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
 
-            {% if post.data.description %}
-            <p class="font-plex text-sm text-fg-2 leading-relaxed mt-2">{{ post.data.description }}</p>
-            {% endif %}
-
-            <div class="mt-4 flex flex-wrap items-center gap-2">
-              <span class="font-jb text-mono-sm text-fg-3">{{ post.date | dateReadable }}</span>
-              <span class="font-jb text-mono-sm text-fg-4">&middot;</span>
-              <span class="font-jb text-mono-sm text-fg-3">{{ post.templateContent | readingTime }}</span>
+            <div v-if="post.thumbnail" class="h-44 bg-surface-inset overflow-hidden">
+              <img
+                :src="post.thumbnail"
+                alt=""
+                loading="lazy"
+                :class="['w-full h-full object-cover', post.thumbnailLogo ? 'object-contain p-6' : '']">
             </div>
 
-            {% if post.data.tags %}
-            <div class="mt-3 flex flex-wrap gap-2">
-              {% for tag in post.data.tags %}
-              {% if tag != "posts" %}
-              <a
-                href="/tags/{{ tag | tagSlug }}/"
-                class="font-jb text-mono-xs tracking-[0.04em] uppercase bg-amber/[0.10] border border-amber/[0.32] text-amber rounded-d-sm px-2 py-0.5 hover:bg-amber/[0.18] transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
-                {{ tag }}
-              </a>
-              {% endif %}
-              {% endfor %}
-            </div>
-            {% endif %}
+            <div class="p-6">
+              <h2 class="font-syne text-lg font-semibold text-fg-1 leading-snug">
+                <a
+                  :href="post.url"
+                  class="hover:text-amber transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
+                  {% raw %}{{ post.title }}{% endraw %}
+                </a>
+              </h2>
 
-          </div>
-        </article>
-        {% endfor %}
+              <p v-if="post.description" class="font-plex text-sm text-fg-2 leading-relaxed mt-2">{% raw %}{{ post.description }}{% endraw %}</p>
+
+              <div class="mt-4 flex flex-wrap items-center gap-2">
+                <span class="font-jb text-mono-sm text-fg-3">{% raw %}{{ post.date }}{% endraw %}</span>
+                <span class="font-jb text-mono-sm text-fg-4">&middot;</span>
+                <span class="font-jb text-mono-sm text-fg-3">{% raw %}{{ post.readingTime }}{% endraw %}</span>
+              </div>
+
+              <div v-if="post.visibleTags.length" class="mt-3 flex flex-wrap gap-2">
+                <button
+                  v-for="tag in post.visibleTags"
+                  :key="tag"
+                  @click="activeTag = tag"
+                  class="font-jb text-mono-xs tracking-[0.04em] uppercase bg-amber/[0.10] border border-amber/[0.32] text-amber rounded-d-sm px-2 py-0.5 hover:bg-amber/[0.18] transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
+                  {% raw %}{{ tag }}{% endraw %}
+                </button>
+              </div>
+            </div>
+          </article>
+        </transition-group>
+
+        <p v-else class="font-plex text-base text-fg-3">No posts for this tag.</p>
       </div>
-      {% else %}
-      <p class="font-plex text-base text-fg-3">No posts yet.</p>
-      {% endif %}
 
     </div>
   </section>
 </div>
+
+<script type="module">
+import { createApp } from 'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.esm-browser.prod.js';
+
+const posts = [
+  {% set postslist = collections.posts | reverse %}
+  {% for post in postslist %}
+  {
+    url: {{ post.url | dump | safe }},
+    title: {{ post.data.title | dump | safe }},
+    description: {{ (post.data.description or "") | dump | safe }},
+    date: {{ (post.date | dateReadable) | dump | safe }},
+    readingTime: {{ (post.templateContent | readingTime) | dump | safe }},
+    thumbnail: {{ (post.data.thumbnail or "") | dump | safe }},
+    thumbnailLogo: {{ (post.data.thumbnailLogo or false) | dump | safe }},
+    tags: {{ (post.data.tags or []) | dump | safe }}
+  }{% if not loop.last %},{% endif %}
+
+  {% endfor %}
+];
+
+createApp({
+  data() {
+    return {
+      posts,
+      activeTag: 'all'
+    };
+  },
+  computed: {
+    allTags() {
+      const set = new Set();
+      this.posts.forEach(p => p.tags.forEach(t => { if (t !== 'posts') set.add(t); }));
+      return [...set];
+    },
+    filteredPosts() {
+      const active = this.activeTag;
+      return this.posts
+        .map(p => ({ ...p, visibleTags: p.tags.filter(t => t !== 'posts') }))
+        .filter(p => active === 'all' || p.tags.includes(active));
+    }
+  }
+}).mount('#blog-app');
+</script>
+
+<style>
+.card-enter-active,
+.card-leave-active { transition: opacity 0.2s ease, transform 0.2s ease; }
+.card-enter-from,
+.card-leave-to { opacity: 0; transform: translateY(8px); }
+.card-move { transition: transform 0.25s ease; }
+</style>

--- a/src/index.njk
+++ b/src/index.njk
@@ -10,21 +10,21 @@ description: AI ops and IT infrastructure portfolio for Levi Huff. University of
   <section id="hero" class="py-16 md:py-20">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; AI OPS &middot; IT INFRASTRUCTURE</p>
+      <p data-motion="hero-item" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; AI OPS &middot; IT INFRASTRUCTURE</p>
 
-      <h1 class="font-syne text-4xl md:text-5xl font-bold leading-[1.1] tracking-[-0.02em] text-fg-1 mt-3">
+      <h1 data-motion="hero-item" class="font-syne text-4xl md:text-5xl font-bold leading-[1.1] tracking-[-0.02em] text-fg-1 mt-3">
         Levi Huff
       </h1>
 
-      <p class="font-plex text-lg text-fg-2 leading-relaxed mt-4 max-w-prose">
+      <p data-motion="hero-item" class="font-plex text-lg text-fg-2 leading-relaxed mt-4 max-w-prose">
         I deploy AI infrastructure, run enterprise IT, and ship the software that connects them.
       </p>
 
-      <p class="font-plex text-sm text-fg-3 mt-3 max-w-prose">
+      <p data-motion="hero-item" class="font-plex text-sm text-fg-3 mt-3 max-w-prose">
         University of Cincinnati IT, graduating {{ site.graduationDate }}. CompTIA A+ and ITF+. Cisco CCNA in progress. Co-op experience at Tire Discounters and Total Quality Logistics.
       </p>
 
-      <div class="mt-8 flex flex-wrap gap-3">
+      <div data-motion="hero-item" class="mt-8 flex flex-wrap gap-3">
         <a
           href="/files/Levi_Huff_Resume.pdf"
           download="Levi_Huff_Resume.pdf"
@@ -45,15 +45,15 @@ description: AI ops and IT infrastructure portfolio for Levi Huff. University of
   <section id="what" class="py-12 md:py-16">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 01 / WHAT I DO</p>
-      <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
+      <p data-motion="section" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 01 / WHAT I DO</p>
+      <h2 data-motion="section" class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
         Two tracks, one operator.
       </h2>
 
-      <div class="mt-8 grid gap-4 md:grid-cols-2">
+      <div data-motion="stagger" class="mt-8 grid gap-4 md:grid-cols-2">
 
         {# IT Infrastructure card #}
-        <div class="bg-surface-2 border border-hair-1 rounded-d-lg p-6 md:p-8 hover:border-hair-2 transition-colors duration-[180ms]">
+        <div data-motion="stagger-item" class="bg-surface-2 border border-hair-1 rounded-d-lg p-6 md:p-8 hover:border-hair-2 transition-colors duration-[180ms]">
           <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-fg-3">IT INFRASTRUCTURE</p>
           <h3 class="font-plex text-2xl font-semibold text-fg-1 mt-2 leading-snug">
             Operate the systems that keep an org running.
@@ -79,7 +79,7 @@ description: AI ops and IT infrastructure portfolio for Levi Huff. University of
         </div>
 
         {# AI Ops card #}
-        <div class="bg-surface-2 border border-hair-1 rounded-d-lg p-6 md:p-8 hover:border-hair-2 transition-colors duration-[180ms]">
+        <div data-motion="stagger-item" class="bg-surface-2 border border-hair-1 rounded-d-lg p-6 md:p-8 hover:border-hair-2 transition-colors duration-[180ms]">
           <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-fg-3">AI OPS</p>
           <h3 class="font-plex text-2xl font-semibold text-fg-1 mt-2 leading-snug">
             Stand up the AI services people actually use.
@@ -112,17 +112,17 @@ description: AI ops and IT infrastructure portfolio for Levi Huff. University of
   <section id="tools" class="py-12 md:py-16">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 02 / TOOLS</p>
-      <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
+      <p data-motion="section" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 02 / TOOLS</p>
+      <h2 data-motion="section" class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
         Stack and tooling.
       </h2>
-      <p class="font-plex text-lg text-fg-2 leading-relaxed mt-3 max-w-prose">
+      <p data-motion="section" class="font-plex text-lg text-fg-2 leading-relaxed mt-3 max-w-prose">
         Technologies I have deployed, maintained, or built with in production and co-op environments.
       </p>
 
-      <div class="mt-8 grid gap-2 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      <div data-motion="stagger" class="mt-8 grid gap-2 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {% for tool in tools %}
-        <div class="bg-surface-2 border border-hair-1 rounded-d-md p-4 hover:border-amber/[0.32] hover:-translate-y-0.5 hover:shadow-d-sm transition-[transform,border-color,box-shadow] duration-[180ms]">
+        <div data-motion="stagger-item" class="bg-surface-2 border border-hair-1 rounded-d-md p-4 hover:border-amber/[0.32] hover:-translate-y-0.5 hover:shadow-d-sm transition-[transform,border-color,box-shadow] duration-[180ms]">
           <p class="font-jb text-sm text-fg-1">{{ tool.name }}</p>
           <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-fg-4 mt-2">{{ tool.category }}</p>
         </div>
@@ -136,12 +136,12 @@ description: AI ops and IT infrastructure portfolio for Levi Huff. University of
   <section id="work" class="py-12 md:py-16">
     <div class="max-w-site mx-auto px-4 md:px-6">
 
-      <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 03 / WORK</p>
-      <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
+      <p data-motion="section" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 03 / WORK</p>
+      <h2 data-motion="section" class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">
         Selected work.
       </h2>
 
-      <div class="mt-8 grid gap-6 md:grid-cols-3">
+      <div data-motion="stagger" class="mt-8 grid gap-6 md:grid-cols-3">
         {% for project in projects %}
           {% if project.featured %}
             {% include "components/landing/project-card-mini.njk" %}

--- a/src/projects.njk
+++ b/src/projects.njk
@@ -11,11 +11,126 @@ description: Portfolio of software development projects including full-stack app
       <h1 class="font-syne text-4xl font-bold leading-[1.1] tracking-[-0.02em] text-fg-1 mt-3">All projects.</h1>
       <p class="font-plex text-lg text-fg-2 leading-relaxed mt-4 max-w-prose">Selected professional co-op work and personal software projects.</p>
 
-      <div class="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {% for project in projects %}
-          {% include "components/project-card.njk" %}
-        {% endfor %}
+      <div id="projects-app" class="mt-12">
+
+        {# Category filter chips #}
+        <div class="flex flex-wrap gap-2 mb-8">
+          <button
+            v-for="cat in categories"
+            :key="cat.value"
+            @click="active = cat.value"
+            :aria-pressed="active === cat.value"
+            :class="[
+              'font-jb text-mono-xs tracking-[0.04em] uppercase px-3 py-1.5 rounded-d-sm border transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2',
+              active === cat.value
+                ? 'bg-amber/[0.18] border-amber/[0.64] text-amber'
+                : 'bg-surface-2 border-hair-1 text-fg-3 hover:text-fg-1 hover:border-hair-2'
+            ]">
+            {% raw %}{{ cat.label }}{% endraw %}
+          </button>
+        </div>
+
+        {# Projects grid #}
+        <transition-group
+          tag="div"
+          name="card"
+          class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <article
+            v-for="project in filteredProjects"
+            :key="project.title"
+            class="bg-surface-2 border border-hair-1 rounded-d-lg overflow-hidden hover:border-hair-2 hover:-translate-y-0.5 hover:shadow-d-md transition-[transform,border-color,box-shadow] duration-[180ms]">
+
+            <div v-if="project.image" class="h-52 bg-surface-inset overflow-hidden">
+              <img
+                :src="project.image"
+                :alt="project.imageAlt"
+                :width="project.imageWidth"
+                :height="project.imageHeight"
+                loading="lazy"
+                :class="['w-full h-full', project.imageClass === 'logo' ? 'object-contain p-6 bg-surface-1' : 'object-cover']">
+            </div>
+
+            <div class="p-6">
+              <p v-if="project.stack" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-fg-3">STACK &middot; {% raw %}{{ project.stack }}{% endraw %}</p>
+
+              <h2 class="font-syne text-xl font-semibold text-fg-1 mt-2 leading-snug">
+                <a
+                  v-if="project.link"
+                  :href="project.link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="hover:text-amber transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
+                  {% raw %}{{ project.title }}{% endraw %}
+                </a>
+                <span v-else>{% raw %}{{ project.title }}{% endraw %}</span>
+              </h2>
+
+              <div v-if="project.description" class="font-plex text-sm text-fg-2 leading-relaxed mt-3" v-html="project.description"></div>
+
+              <dl v-if="project.paragraphs && project.paragraphs.length" class="mt-4 space-y-2">
+                <div
+                  v-for="para in project.paragraphs"
+                  :key="para.label"
+                  class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-3">
+                  <dt class="font-jb text-sm text-amber sm:w-36 shrink-0">{% raw %}{{ para.label }}{% endraw %}</dt>
+                  <dd class="font-plex text-sm text-fg-2">{% raw %}{{ para.text }}{% endraw %}</dd>
+                </div>
+              </dl>
+
+              <p v-if="project.meta" class="font-jb text-mono-xs tracking-[0.04em] uppercase text-fg-4 mt-4">{% raw %}{{ project.meta }}{% endraw %}</p>
+
+              <a
+                v-if="project.link"
+                :href="project.link"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 mt-5 font-jb text-sm text-fg-2 hover:text-amber transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2">
+                {% raw %}{{ project.linkLabel || 'View' }}{% endraw %} &rarr;
+              </a>
+            </div>
+
+          </article>
+        </transition-group>
+
+        <p v-if="!filteredProjects.length" class="font-plex text-base text-fg-3">No projects in this category.</p>
+
       </div>
     </div>
   </section>
 </div>
+
+<script type="module">
+import { createApp } from 'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.esm-browser.prod.js';
+
+const projects = {{ projects | dump | safe }};
+
+createApp({
+  data() {
+    return {
+      projects,
+      active: 'all',
+      categories: [
+        { value: 'all',            label: 'All' },
+        { value: 'software',       label: 'Software' },
+        { value: 'infrastructure', label: 'Infrastructure' },
+        { value: 'ai',             label: 'AI' },
+        { value: 'work',           label: 'Work' }
+      ]
+    };
+  },
+  computed: {
+    filteredProjects() {
+      if (this.active === 'all') return this.projects;
+      return this.projects.filter(p => p.category === this.active);
+    }
+  }
+}).mount('#projects-app');
+</script>
+
+<style>
+.card-enter-active,
+.card-leave-active { transition: opacity 0.2s ease, transform 0.2s ease; }
+.card-enter-from,
+.card-leave-to { opacity: 0; transform: translateY(8px); }
+.card-move { transition: transform 0.25s ease; }
+</style>

--- a/src/projects.njk
+++ b/src/projects.njk
@@ -11,6 +11,14 @@ description: Portfolio of software development projects including full-stack app
       <h1 class="font-syne text-4xl font-bold leading-[1.1] tracking-[-0.02em] text-fg-1 mt-3">All projects.</h1>
       <p class="font-plex text-lg text-fg-2 leading-relaxed mt-4 max-w-prose">Selected professional co-op work and personal software projects.</p>
 
+      {# Static fallback — always visible; Vue removes it on mount #}
+      <div id="projects-static" class="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {% for project in projects %}
+        {% set project = project %}
+        {% include "components/project-card.njk" %}
+        {% endfor %}
+      </div>
+
       <div id="projects-app" class="mt-12" v-cloak>
 
         {# Category filter chips #}
@@ -123,6 +131,9 @@ createApp({
       if (this.active === 'all') return this.projects;
       return this.projects.filter(p => p.category === this.active);
     }
+  },
+  mounted() {
+    document.getElementById('projects-static')?.remove();
   }
 }).mount('#projects-app');
 </script>

--- a/src/projects.njk
+++ b/src/projects.njk
@@ -11,7 +11,7 @@ description: Portfolio of software development projects including full-stack app
       <h1 class="font-syne text-4xl font-bold leading-[1.1] tracking-[-0.02em] text-fg-1 mt-3">All projects.</h1>
       <p class="font-plex text-lg text-fg-2 leading-relaxed mt-4 max-w-prose">Selected professional co-op work and personal software projects.</p>
 
-      <div id="projects-app" class="mt-12">
+      <div id="projects-app" class="mt-12" v-cloak>
 
         {# Category filter chips #}
         <div class="flex flex-wrap gap-2 mb-8">

--- a/src/resume.njk
+++ b/src/resume.njk
@@ -189,62 +189,54 @@ description: Resume for Levi Huff — IT graduate and infrastructure specialist 
     </div>
   </section>
 
-  {# Technical Skills #}
+  {# Technical Skills — Vue tab switcher #}
   <section class="py-12 md:py-16">
     <div class="max-w-site mx-auto px-4 md:px-6">
       <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 05 / SKILLS</p>
       <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">Technical skills.</h2>
 
-      <div class="mt-8 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Systems and Infrastructure</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>Windows Server, Azure AD, Active Directory</li>
-            <li>Intune, MDT, SCCM, GPO, Autopilot, BitLocker</li>
-          </ul>
+      <div id="skills-app" class="mt-8">
+        {# Tab buttons #}
+        <div role="tablist" aria-label="Skill categories" class="flex flex-wrap gap-2 mb-6">
+          <button
+            v-for="(group, i) in groups"
+            :key="group.heading"
+            role="tab"
+            :aria-selected="active === i"
+            :id="'tab-' + i"
+            :aria-controls="'panel-' + i"
+            @click="active = i"
+            :class="[
+              'font-jb text-mono-xs tracking-[0.04em] uppercase px-3 py-1.5 rounded-d-sm border transition-colors duration-[120ms] focus-visible:outline-[3px] focus-visible:outline-amber focus-visible:outline-offset-2',
+              active === i
+                ? 'bg-amber/[0.18] border-amber/[0.64] text-amber'
+                : 'bg-surface-2 border-hair-1 text-fg-3 hover:text-fg-1 hover:border-hair-2'
+            ]">
+            {% raw %}{{ group.heading }}{% endraw %}
+          </button>
         </div>
 
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Automation and Scripting</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>PowerShell, Bash, Python</li>
-            <li>Task Scheduler</li>
-          </ul>
-        </div>
-
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Development</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>C#, ASP.NET, Java, Spring Boot, Kotlin</li>
-            <li>HTML, CSS, JavaScript, OOP</li>
-            <li>SQL Server, SQLite, REST APIs, Git</li>
-          </ul>
-        </div>
-
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Networking and Security</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>DHCP, DNS, VPN, VLAN, TCP/IP, SMTP</li>
-            <li>Firewall, Zero Trust, SIEM, Endpoint Security</li>
-          </ul>
-        </div>
-
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Support and Tools</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>Jira, ServiceNow, SysAid</li>
-            <li>Microsoft Office, Outlook, SharePoint</li>
-            <li>TeamViewer, RDP</li>
-          </ul>
-        </div>
-
-        <div>
-          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">Platforms</h3>
-          <ul class="space-y-1 font-plex text-sm text-fg-2">
-            <li>Windows, Linux, macOS, Azure</li>
-            <li>Android, Docker, VMware</li>
-          </ul>
-        </div>
+        {# Tab panels #}
+        <transition name="tab" mode="out-in">
+          <div
+            v-for="(group, i) in groups"
+            v-show="active === i"
+            :key="group.heading"
+            role="tabpanel"
+            :id="'panel-' + i"
+            :aria-labelledby="'tab-' + i"
+            class="bg-surface-2 border border-hair-1 rounded-d-lg p-6">
+            <dl class="space-y-3">
+              <div
+                v-for="item in group.items"
+                :key="item.label"
+                class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-3">
+                <dt class="font-jb text-sm text-amber sm:w-40 shrink-0">{% raw %}{{ item.label }}{% endraw %}</dt>
+                <dd class="font-plex text-sm text-fg-2">{% raw %}{{ item.text }}{% endraw %}</dd>
+              </div>
+            </dl>
+          </div>
+        </transition>
       </div>
     </div>
   </section>
@@ -288,3 +280,68 @@ description: Resume for Levi Huff — IT graduate and infrastructure specialist 
   </section>
 
 </div>
+
+<script type="module">
+import { createApp } from 'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.esm-browser.prod.js';
+
+createApp({
+  data() {
+    return {
+      active: 0,
+      groups: [
+        {
+          heading: 'Systems',
+          items: [
+            { label: 'Windows',    text: 'Windows Server, Azure AD, Active Directory' },
+            { label: 'Deployment', text: 'Intune, MDT, SCCM, GPO, Autopilot, BitLocker' }
+          ]
+        },
+        {
+          heading: 'Scripting',
+          items: [
+            { label: 'Languages', text: 'PowerShell, Bash, Python' },
+            { label: 'Scheduling', text: 'Task Scheduler' }
+          ]
+        },
+        {
+          heading: 'Development',
+          items: [
+            { label: 'Backend',  text: 'C#, ASP.NET, Java, Spring Boot, Kotlin' },
+            { label: 'Frontend', text: 'HTML, CSS, JavaScript, OOP' },
+            { label: 'Data',     text: 'SQL Server, SQLite, REST APIs, Git' }
+          ]
+        },
+        {
+          heading: 'Networking',
+          items: [
+            { label: 'Protocols', text: 'DHCP, DNS, VPN, VLAN, TCP/IP, SMTP' },
+            { label: 'Security',  text: 'Firewall, Zero Trust, SIEM, Endpoint Security' }
+          ]
+        },
+        {
+          heading: 'Support',
+          items: [
+            { label: 'Ticketing', text: 'Jira, ServiceNow, SysAid' },
+            { label: 'Office',    text: 'Microsoft Office, Outlook, SharePoint' },
+            { label: 'Remote',    text: 'TeamViewer, RDP' }
+          ]
+        },
+        {
+          heading: 'Platforms',
+          items: [
+            { label: 'OS',      text: 'Windows, Linux, macOS, Azure' },
+            { label: 'Infra',   text: 'Android, Docker, VMware' }
+          ]
+        }
+      ]
+    };
+  }
+}).mount('#skills-app');
+</script>
+
+<style>
+.tab-enter-active,
+.tab-leave-active { transition: opacity 0.15s ease, transform 0.15s ease; }
+.tab-enter-from { opacity: 0; transform: translateX(8px); }
+.tab-leave-to  { opacity: 0; transform: translateX(-8px); }
+</style>

--- a/src/resume.njk
+++ b/src/resume.njk
@@ -195,7 +195,7 @@ description: Resume for Levi Huff — IT graduate and infrastructure specialist 
       <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 05 / SKILLS</p>
       <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">Technical skills.</h2>
 
-      <div id="skills-app" class="mt-8">
+      <div id="skills-app" class="mt-8" v-cloak>
         {# Tab buttons #}
         <div role="tablist" aria-label="Skill categories" class="flex flex-wrap gap-2 mb-6">
           <button
@@ -219,16 +219,15 @@ description: Resume for Levi Huff — IT graduate and infrastructure specialist 
         {# Tab panels #}
         <transition name="tab" mode="out-in">
           <div
-            v-for="(group, i) in groups"
-            v-show="active === i"
-            :key="group.heading"
+            v-if="activeGroup"
+            :key="activeGroup.heading"
             role="tabpanel"
-            :id="'panel-' + i"
-            :aria-labelledby="'tab-' + i"
+            :id="'panel-' + active"
+            :aria-labelledby="'tab-' + active"
             class="bg-surface-2 border border-hair-1 rounded-d-lg p-6">
             <dl class="space-y-3">
               <div
-                v-for="item in group.items"
+                v-for="item in activeGroup.items"
                 :key="item.label"
                 class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-3">
                 <dt class="font-jb text-sm text-amber sm:w-40 shrink-0">{% raw %}{{ item.label }}{% endraw %}</dt>
@@ -335,6 +334,11 @@ createApp({
         }
       ]
     };
+  },
+  computed: {
+    activeGroup() {
+      return this.groups[this.active] ?? null;
+    }
   }
 }).mount('#skills-app');
 </script>

--- a/src/resume.njk
+++ b/src/resume.njk
@@ -195,14 +195,34 @@ description: Resume for Levi Huff — IT graduate and infrastructure specialist 
       <p class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber" aria-hidden="true">&#9658; 05 / SKILLS</p>
       <h2 class="font-syne text-3xl font-semibold leading-snug tracking-[-0.02em] text-fg-1 mt-2">Technical skills.</h2>
 
+      {# Static fallback — always visible; Vue removes it on mount #}
+      <div id="skills-static" class="mt-8 space-y-4">
+        {% for group in skills %}
+        <div>
+          <h3 class="font-jb text-mono-xs tracking-[0.04em] uppercase text-amber mb-3">{{ group.heading }}</h3>
+          <div class="bg-surface-2 border border-hair-1 rounded-d-lg p-6">
+            <dl class="space-y-3">
+              {% for item in group.items %}
+              <div class="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-3">
+                <dt class="font-jb text-sm text-amber sm:w-40 shrink-0">{{ item.label }}</dt>
+                <dd class="font-plex text-sm text-fg-2">{{ item.text }}</dd>
+              </div>
+              {% endfor %}
+            </dl>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+
       <div id="skills-app" class="mt-8" v-cloak>
         {# Tab buttons #}
-        <div role="tablist" aria-label="Skill categories" class="flex flex-wrap gap-2 mb-6">
+        <div role="tablist" aria-label="Skill categories" class="flex flex-wrap gap-2 mb-6" @keydown="onTabKey">
           <button
             v-for="(group, i) in groups"
             :key="group.heading"
             role="tab"
             :aria-selected="active === i"
+            :tabindex="active === i ? 0 : -1"
             :id="'tab-' + i"
             :aria-controls="'panel-' + i"
             @click="active = i"
@@ -339,6 +359,22 @@ createApp({
     activeGroup() {
       return this.groups[this.active] ?? null;
     }
+  },
+  methods: {
+    onTabKey(e) {
+      const len = this.groups.length;
+      let next = this.active;
+      if      (e.key === 'ArrowRight') { e.preventDefault(); next = (this.active + 1) % len; }
+      else if (e.key === 'ArrowLeft')  { e.preventDefault(); next = (this.active - 1 + len) % len; }
+      else if (e.key === 'Home')       { e.preventDefault(); next = 0; }
+      else if (e.key === 'End')        { e.preventDefault(); next = len - 1; }
+      else return;
+      this.active = next;
+      this.$nextTick(() => document.getElementById('tab-' + next)?.focus());
+    }
+  },
+  mounted() {
+    document.getElementById('skills-static')?.remove();
   }
 }).mount('#skills-app');
 </script>

--- a/test/blog.test.js
+++ b/test/blog.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createRequire } from "module";
-import { readdirSync, readFileSync } from "fs";
+import { readdirSync, readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, resolve, extname } from "path";
 
@@ -8,7 +8,9 @@ const require = createRequire(import.meta.url);
 const matter = require("gray-matter");
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const blogDir = resolve(__dirname, "../src/blog");
+const root = resolve(__dirname, "..");
+const blogDir = resolve(root, "src/blog");
+const imagesDir = resolve(root, "src/images");
 
 const blogFiles = readdirSync(blogDir).filter((f) => extname(f) === ".md");
 
@@ -72,6 +74,16 @@ describe("blog post frontmatter", () => {
         "string"
       );
       expect(data.thumbnail.trim(), `empty thumbnail in ${file}`).not.toBe("");
+    }
+  });
+
+  it("every post thumbnail file exists in src/images/", () => {
+    for (const file of blogFiles) {
+      const { data } = matter(readFileSync(resolve(blogDir, file), "utf8"));
+      if (!data.thumbnail) continue;
+      // thumbnail is root-relative e.g. /images/blog/foo.jpg → src/images/blog/foo.jpg
+      const imgPath = resolve(root, "src", data.thumbnail.replace(/^\//, ""));
+      expect(existsSync(imgPath), `missing image ${data.thumbnail} referenced in ${file}`).toBe(true);
     }
   });
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -126,6 +126,41 @@ describe("build smoke test", () => {
     expect(broken, `Broken links:\n${broken.join("\n")}`).toHaveLength(0);
   });
 
+  // Meta / OG tags
+  it("index.html has a non-empty <title>", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    const match = html.match(/<title>([^<]*)<\/title>/i);
+    expect(match, "no <title> found").toBeTruthy();
+    expect(match[1].trim()).not.toBe("");
+  });
+
+  it("index.html has a meta description", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    expect(html).toMatch(/<meta\s[^>]*name=["']description["'][^>]*>/i);
+  });
+
+  it("index.html has og:title and og:description meta tags", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    expect(html).toMatch(/property=["']og:title["']/i);
+    expect(html).toMatch(/property=["']og:description["']/i);
+  });
+
+  // Individual blog post pages
+  it("at least one individual blog post page is built", () => {
+    const blogDir = resolve(siteDir, "blog");
+    const entries = readdirSync(blogDir, { withFileTypes: true });
+    const postDirs = entries.filter(
+      (e) => e.isDirectory() && existsSync(resolve(blogDir, e.name, "index.html"))
+    );
+    expect(postDirs.length).toBeGreaterThan(0);
+  });
+
+  // feed.xml has entries
+  it("feed.xml contains at least one <entry> element", () => {
+    const feed = readFileSync(resolve(siteDir, "feed.xml"), "utf8");
+    expect(feed).toMatch(/<entry>/i);
+  });
+
   // img alt text
   it("no <img> element in built HTML is missing an alt attribute", () => {
     const htmlFiles = findHtmlFiles(siteDir);

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -86,6 +86,10 @@ describe("dateYMD", () => {
   it("output matches YYYY-MM-DD format", () => {
     expect(dateYMD("2024-03-07")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
+  it("accepts a Date object and returns YYYY-MM-DD", () => {
+    const d = new Date(Date.UTC(2024, 5, 1)); // June 1 2024 UTC — timezone-safe
+    expect(dateYMD(d)).toBe("2024-06-01");
+  });
 });
 
 describe("safeCdata", () => {


### PR DESCRIPTION
## Summary

- **Vue 3 CDN islands** on three pages — no changes to the 11ty/npm build pipeline, loaded via `<script type="module">` from jsDelivr
- **Motion One** (`motion@10`) scroll animations sitewide, added to `base.njk`, respects `prefers-reduced-motion`

## Vue islands

| Page | Feature |
|---|---|
| `/blog/` | Tag filter chips — click any tag to filter cards live; `<TransitionGroup>` fade/slide on card enter/exit |
| `/resume/` | Skills tab switcher — 6 tab buttons (Systems, Scripting, Development, Networking, Support, Platforms) replace the static grid; slide transition between panels |
| `/projects/` | Category filter — All / Software / Infrastructure / AI / Work; cards filter with `<TransitionGroup>` |

Added `category` field to each entry in `projects.json` to power the project filter.

## Motion One animations

| Animation | Targets |
|---|---|
| Hero stagger | Eyebrow → h1 → tagline → description → CTA buttons, 120ms stagger on page load |
| Scroll section reveals | Section headings and content blocks fade + slide up as they enter the viewport |
| Stagger grids | Tools grid (24 cards, 50ms each) and selected work project cards cascade in on scroll |

`data-motion` attributes added to homepage elements; Motion One initializes in `base.njk` after page load.

## Test plan

- [ ] `/blog/` — tag chips filter cards; "All" shows everything; clicking a tag on a card also filters
- [ ] `/resume/` — tab buttons switch skill panels with slide animation; all 6 groups accessible
- [ ] `/projects/` — category chips filter correctly; "AI" shows 1 project, "Work" shows 4, etc.
- [ ] Homepage — hero elements stagger in on first load; tools grid and project cards animate on scroll
- [ ] `prefers-reduced-motion: reduce` — no Motion One animations fire; Vue transitions are CSS-based and also respect the media query if set

https://claude.ai/code/session_016ungAxzVURBuie7SxfxWr7

---
_Generated by [Claude Code](https://claude.ai/code/session_016ungAxzVURBuie7SxfxWr7)_