### PR TITLE
Extend test coverage: meta tags, blog post pages, feed entries, thumbnail existence, dateYMD Date object

### DIFF
--- a/test/blog.test.js
+++ b/test/blog.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createRequire } from "module";
-import { readdirSync, readFileSync } from "fs";
+import { readdirSync, readFileSync, existsSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, resolve, extname } from "path";
 
@@ -8,7 +8,9 @@ const require = createRequire(import.meta.url);
 const matter = require("gray-matter");
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const blogDir = resolve(__dirname, "../src/blog");
+const root = resolve(__dirname, "..");
+const blogDir = resolve(root, "src/blog");
+const imagesDir = resolve(root, "src/images");
 
 const blogFiles = readdirSync(blogDir).filter((f) => extname(f) === ".md");
 
@@ -72,6 +74,16 @@ describe("blog post frontmatter", () => {
         "string"
       );
       expect(data.thumbnail.trim(), `empty thumbnail in ${file}`).not.toBe("");
+    }
+  });
+
+  it("every post thumbnail file exists in src/images/", () => {
+    for (const file of blogFiles) {
+      const { data } = matter(readFileSync(resolve(blogDir, file), "utf8"));
+      if (!data.thumbnail) continue;
+      // thumbnail is root-relative e.g. /images/blog/foo.jpg → src/images/blog/foo.jpg
+      const imgPath = resolve(root, "src", data.thumbnail.replace(/^\//, ""));
+      expect(existsSync(imgPath), `missing image ${data.thumbnail} referenced in ${file}`).toBe(true);
     }
   });
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -126,6 +126,41 @@ describe("build smoke test", () => {
     expect(broken, `Broken links:\n${broken.join("\n")}`).toHaveLength(0);
   });
 
+  // Meta / OG tags
+  it("index.html has a non-empty <title>", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    const match = html.match(/<title>([^<]*)<\/title>/i);
+    expect(match, "no <title> found").toBeTruthy();
+    expect(match[1].trim()).not.toBe("");
+  });
+
+  it("index.html has a meta description", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    expect(html).toMatch(/<meta\s[^>]*name=["']description["'][^>]*>/i);
+  });
+
+  it("index.html has og:title and og:description meta tags", () => {
+    const html = readFileSync(resolve(siteDir, "index.html"), "utf8");
+    expect(html).toMatch(/property=["']og:title["']/i);
+    expect(html).toMatch(/property=["']og:description["']/i);
+  });
+
+  // Individual blog post pages
+  it("at least one individual blog post page is built", () => {
+    const blogDir = resolve(siteDir, "blog");
+    const entries = readdirSync(blogDir, { withFileTypes: true });
+    const postDirs = entries.filter(
+      (e) => e.isDirectory() && existsSync(resolve(blogDir, e.name, "index.html"))
+    );
+    expect(postDirs.length).toBeGreaterThan(0);
+  });
+
+  // feed.xml has entries
+  it("feed.xml contains at least one <entry> element", () => {
+    const feed = readFileSync(resolve(siteDir, "feed.xml"), "utf8");
+    expect(feed).toMatch(/<entry>/i);
+  });
+
   // img alt text
   it("no <img> element in built HTML is missing an alt attribute", () => {
     const htmlFiles = findHtmlFiles(siteDir);

--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -86,6 +86,10 @@ describe("dateYMD", () => {
   it("output matches YYYY-MM-DD format", () => {
     expect(dateYMD("2024-03-07")).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
+  it("accepts a Date object and returns YYYY-MM-DD", () => {
+    const d = new Date(Date.UTC(2024, 5, 1)); // June 1 2024 UTC — timezone-safe
+    expect(dateYMD(d)).toBe("2024-06-01");
+  });
 });
 
 describe("safeCdata", () => {


### PR DESCRIPTION
## Summary

- **`build.test.js`**: add meta/OG tag checks (`<title>`, `meta[name=description]`, `og:title`, `og:description`), verify individual blog post pages are built, verify `feed.xml` contains at least one `<entry>`
- **`blog.test.js`**: add thumbnail file existence check — confirms each post's `thumbnail` path resolves to a real file in `src/images/`
- **`filters.test.js`**: add `dateYMD` test with a `Date` object input (Eleventy passes `Date` objects from frontmatter)

All 80 tests pass locally.

## Test plan

- [ ] CI passes on this PR
- [ ] Rename or delete a thumbnail image and confirm the new test catches it
- [ ] Remove a meta tag from `base.njk` and confirm the new test catches it

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPBJujWEw1tmXrgWpnjkVx)_