### PR TITLE
chore(security): add repo security guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule: { interval: weekly }
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule: { interval: weekly }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
         run: npm run test && npm run build
 
       - name: Upload to FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@8e83cea8672e3fbcbb9fdafff34debf6ae4c5f65  # v4.3.5
         with:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,42 @@
+name: security
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  secret-scan:
+    name: gitleaks (secrets, full history)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # REQUIRED for PR scans
+          GITLEAKS_CONFIG: .gitleaks.toml
+
+  env-guard:
+    name: no real .env tracked
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - run: |
+          tracked="$(git ls-files | grep -E '\.env(\..*)?$' | grep -v '\.env\.example$' || true)"
+          if [ -n "$tracked" ]; then echo "::error::real .env tracked:"; echo "$tracked"; exit 1; fi
+          echo "OK: no real .env tracked."
+
+  dependency-scan:
+    name: npm audit (high+)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with: { node-version: "lts/*", cache: npm }
+      - run: npm ci
+      - run: npm audit --audit-level=high   # fails on HIGH/CRITICAL advisories

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,11 @@ node_modules/
 _site/
 .DS_Store
 
+# Secrets / local env — keep real secrets out of git
+.env
+*.env
+*.env.local
+!*.env.example   # but DO track the documented template
+
 # Claude Code — credentials, cache, and ephemeral agent state
 .claude/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+title = "gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Allow example templates and angle-bracket placeholders ONLY"
+paths = [ '''.*\.env\.example$''' ]
+regexes = [ '''<[a-z0-9-]+>''' ]   # e.g. <api-key>, <token>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks: [ { id: gitleaks } ]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ["--maxkb=2048"]
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: check-yaml
+
+  # Hard-fail if a real .env is staged (e.g. via `git add -f`)
+  - repo: local
+    hooks:
+      - id: forbid-real-env
+        name: block real .env files (use .env.example)
+        language: fail
+        entry: "Real .env files must never be committed."
+        files: '\.env(\..*)?$'
+        exclude: '\.env\.example$'


### PR DESCRIPTION
Replicates the **Repo Security Guardrails Runbook** for this npm static site — defense-in-depth so a secret or known-vulnerable dependency can't be committed, pushed, or merged.

## Changes
- **Layer 1 (commit-time):** `.gitignore` `.env` rules, `.gitleaks.toml` (narrow allowlist), `.pre-commit-config.yaml` (gitleaks, detect-private-key, large-file/merge/yaml checks, `forbid-real-env`).
- **Layer 2:** `.github/dependabot.yml` — weekly npm + github-actions updates. (Vulnerability alerts / security updates enabled via API.)
- **Layer 3 (CI):** `.github/workflows/security.yml` — three required-gate jobs: `gitleaks (secrets, full history)`, `no real .env tracked`, `npm audit (high+)`.
- **Layer 5:** all GitHub Actions pinned to commit SHAs (new `security.yml` and existing `deploy.yml`).

## Already in place
Repo is public; GitHub secret scanning + push protection already enabled.

## Follow-ups (done outside this PR)
- Enable Dependabot vulnerability alerts + automated security fixes.
- Update the `main` ruleset to require the three job names above (replacing the stale `test` context) — done **after** these checks first run so the contexts exist.
- Enable CodeQL default setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)