### PR TITLE
fix(ci): set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ftp-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Resolves code scanning alerts [#4](https://github.com/lh1207/levihuff.net/security/code-scanning/4) and [#5](https://github.com/lh1207/levihuff.net/security/code-scanning/5) (CodeQL rule `actions/missing-workflow-permissions`, medium severity).

Neither workflow declared an explicit `permissions` block, so the `GITHUB_TOKEN` fell back to the repo/org default scope (potentially read-write), violating least privilege.

## Changes

- `.github/workflows/ci.yml` — add `permissions: contents: read` at workflow root
- `.github/workflows/deploy.yml` — add `permissions: contents: read` at workflow root

Both workflows only read the repo (checkout + npm test/build). The FTP deploy authenticates with `secrets.FTP_*`, not the `GITHUB_TOKEN`, so `contents: read` is sufficient — no write scopes required.

## Verification

- `npm test` — 83 tests pass
- Both alerts auto-resolve once merged to `main` (next CodeQL run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)